### PR TITLE
Add Transaction History Pagination Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,22 @@ A Clarity smart contract system for monitoring and tracking on-chain activity on
 - Monitor specific addresses
 - Store historical transaction data
 - Query transaction history and stats
+- Paginated transaction history queries
 
 ## Contract Functions
 - `add-tracked-address`: Add an address to monitor
 - `remove-tracked-address`: Remove an address from monitoring
 - `log-transaction`: Log transaction details for tracked addresses
-- `get-transaction-history`: Query transaction history for an address
+- `get-transaction`: Get a specific transaction by ID
+- `get-transactions-page`: Get paginated transaction history for an address
 - `get-stats`: Get statistics for tracked addresses
 
 ## Usage
-[Include usage examples and deployment instructions]
+### Querying Transaction History
+To retrieve transaction history for an address, use the `get-transactions-page` function:
+```clarity
+(get-transactions-page address page-number)
+```
+Each page contains up to 50 transactions, sorted by transaction ID.
+
+[Additional usage examples and deployment instructions]

--- a/contracts/crypto-scope.clar
+++ b/contracts/crypto-scope.clar
@@ -5,6 +5,7 @@
 (define-constant err-owner-only (err u100))
 (define-constant err-invalid-address (err u101))
 (define-constant err-not-tracked (err u102))
+(define-constant max-tx-per-page u50)
 
 ;; Data structures
 (define-map tracked-addresses principal bool)
@@ -53,4 +54,21 @@
 
 (define-read-only (get-transaction (address principal) (tx-id uint))
   (map-get? transaction-logs { address: address, tx-id: tx-id })
+)
+
+(define-read-only (get-transactions-page (address principal) (page uint))
+  (let
+    (
+      (start-id (* page max-tx-per-page))
+      (end-id (+ start-id max-tx-per-page))
+    )
+    (filter not-none 
+      (map 
+        (lambda (id) 
+          (map-get? transaction-logs { address: address, tx-id: id })
+        )
+        (list-range-uint start-id end-id)
+      )
+    )
+  )
 )

--- a/tests/crypto-scope_test.ts
+++ b/tests/crypto-scope_test.ts
@@ -30,7 +30,7 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "Ensure can log transactions for tracked addresses",
+  name: "Ensure can log transactions and retrieve pages",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const wallet1 = accounts.get("wallet_1")!;
@@ -49,5 +49,16 @@ Clarinet.test({
       )
     ]);
     assertEquals(block.receipts[1].result, '(ok u0)');
+
+    block = chain.mineBlock([
+      Tx.contractCall("crypto-scope", "get-transactions-page",
+        [
+          types.principal(wallet1.address),
+          types.uint(0)
+        ],
+        deployer.address
+      )
+    ]);
+    assertEquals(block.receipts[0].result.includes('amount: u1000'), true);
   }
 });


### PR DESCRIPTION
This PR adds pagination support for querying transaction history in the CryptoScope contract. The enhancement improves scalability and usability when dealing with addresses that have many transactions.

Changes:
- Added new `get-transactions-page` read-only function
- Set maximum page size to 50 transactions
- Updated tests to cover pagination functionality
- Updated documentation in README

The pagination feature allows clients to efficiently retrieve transaction history in manageable chunks instead of having to query individual transactions or potentially overloading responses with too much data.

Implementation Details:
- Page size is fixed at 50 transactions
- Pages are zero-indexed
- Empty/invalid transactions are filtered out of results
- Results are ordered by transaction ID

No breaking changes were introduced - all existing functionality remains unchanged.